### PR TITLE
update code that can use embd_type information

### DIFF
--- a/dsrl_model/model_free/safecl_jax.py
+++ b/dsrl_model/model_free/safecl_jax.py
@@ -30,6 +30,8 @@ from dsrl_model.utils.models_jax import (
     EnsembleValue,
     SafeDiceTanhMixtureActor,
     TransformerEmbedding,
+    TransformerEmbeddingCostant,
+    TransformerEmbeddingNoProjection,
     get_tree_norm,
     softer_max,
 )
@@ -930,6 +932,8 @@ def main(args, cfg_env=None):
     config["pi_baseline_type"] = args.policy_baseline_type
     config["pi_alpha"] = args.alpha
 
+    config["embd_type"] = args.embedding_model_type
+
     config["train_horizon"] = args.train_horizon or config.get("train_horizon")
     config["normalize_observation"] = args.normalize_observation
     config["value_limit"] = args.value_weight_limit or config["value_limit"]
@@ -987,14 +991,39 @@ def main(args, cfg_env=None):
     )
 
     embd_size = config["embd_size"]
-    embedding_model = TransformerEmbedding(
-        rngs=rngs,
-        obs_dim=obs_space.shape[0],
-        act_dim=act_space.shape[0],
-        horizon=config["train_horizon"],
-        embd_dim=embd_size,
-        num_attentions=2,
-    )
+    if config["embd_type"] == "model_projection":
+        embedding_model = TransformerEmbedding(
+            rngs=rngs,
+            obs_dim=obs_space.shape[0],
+            act_dim=act_space.shape[0],
+            horizon=config["train_horizon"],
+            embd_dim=embd_size,
+            num_attentions=2,
+        )
+    elif config["embd_type"] == "constant_projection":
+        embedding_model = TransformerEmbeddingCostant(
+            rngs=rngs,
+            obs_dim=obs_space.shape[0],
+            act_dim=act_space.shape[0],
+            horizon=config["train_horizon"],
+            embd_dim=embd_size,
+            num_attentions=2,
+        )
+    elif config["embd_type"] == "no_projection":
+        embedding_model = TransformerEmbeddingNoProjection(
+            rngs=rngs,
+            obs_dim=obs_space.shape[0],
+            act_dim=act_space.shape[0],
+            horizon=config["train_horizon"],
+            embd_dim=embd_size,
+            num_attentions=2,
+        )
+    else:
+        raise ValueError(
+            "Embedding type not valid. "
+            + "It should be either 'no_projection', 'constant_projection', 'model_projection'. "
+            + f"Given embedding type: {config['embd_type']}."
+        )
     embedding_optimizer = nnx.Optimizer(
         model=embedding_model,
         tx=optax.chain(

--- a/dsrl_model/utils/models_jax.py
+++ b/dsrl_model/utils/models_jax.py
@@ -406,3 +406,80 @@ class TransformerEmbedding(nnx.Module):
         # batch
         score = jnp.einsum("ij,ij->i", attn_weights, traj_score)
         return score
+
+
+class TransformerEmbeddingNoProjection(TransformerEmbedding):
+    def __init__(
+        self,
+        rngs,
+        obs_dim,
+        act_dim,
+        horizon,
+        embd_dim=128,
+        num_heads=4,
+        num_attentions=1,
+        do_layer_norm=True,
+        do_residual=True,
+    ):
+        super().__init__(
+            rngs,
+            obs_dim,
+            act_dim,
+            horizon,
+            embd_dim,
+            num_heads,
+            num_attentions,
+            do_layer_norm,
+            do_residual,
+        )
+        self.pre_score = nnx.Sequential(
+            nnx.Linear(embd_dim, embd_dim, rngs=rngs),
+            nnx.elu,
+            nnx.Linear(embd_dim, 1, rngs=rngs),
+        )
+
+    def get_score(self, x, ztarget, normalize_z=True, training=True):
+        del ztarget
+        # batch X horizon X embd_dim
+        z = self.z(x, normalize_z, training)
+        z = z[:, -1, :]
+        # batch
+        score = nnx.tanh(self.pre_score(z).squeeze(axis=-1))
+        return score
+
+
+class TransformerEmbeddingCostant(TransformerEmbedding):
+    def __init__(
+        self,
+        rngs,
+        obs_dim,
+        act_dim,
+        horizon,
+        embd_dim=128,
+        num_heads=4,
+        num_attentions=1,
+        do_layer_norm=True,
+        do_residual=True,
+    ):
+        super().__init__(
+            rngs,
+            obs_dim,
+            act_dim,
+            horizon,
+            embd_dim,
+            num_heads,
+            num_attentions,
+            do_layer_norm,
+            do_residual,
+        )
+        direction = jax.random.normal(rngs(), shape=(embd_dim,), dtype=jnp.float32)
+        self.unit_direction = l2_normalize(direction, axis=-1)
+        self.embd_dim = embd_dim
+
+    def get_score(self, x, ztarget, normalize_z=True, training=True):
+        del ztarget
+        batch, horizon, _ = x.shape
+        ztarget = jnp.broadcast_to(
+            self.unit_direction, shape=(batch, horizon, self.embd_dim)
+        )
+        return super().get_score(x, ztarget, normalize_z, training)

--- a/dsrl_model/utils/utils.py
+++ b/dsrl_model/utils/utils.py
@@ -361,6 +361,12 @@ def single_agent_args():
             "help": "policy baseline type can be 'constant', 'softer_max', 'mean_std'",
         },
         {
+            "name": "--embedding-model-type",
+            "type": str,
+            "default": "model_projection",
+            "help": "embedding model type can be 'no_projection', 'constant_projection', 'model_projection'",
+        },
+        {
             "name": "--alpha",
             "type": float,
             "default": 0.9,


### PR DESCRIPTION
Add different target embedding representation model:
- constant target model
- no target model, use the parameterized embedding model to directly learn a regression value between [-1, 1].